### PR TITLE
Remove (optional) label from ID card number input

### DIFF
--- a/components/ReporterInput.js
+++ b/components/ReporterInput.js
@@ -167,7 +167,6 @@ const ReporterInput = ({
         <div className="flex justify-between items-center">
           <label className="text-sm font-medium text-gray-800">
             {language === 'en' ? 'ID Card Number' : 'เลขบัตรประชาชน'}
-            <span className="ml-2 text-xs text-gray-400">{language === 'en' ? '(optional)' : '(ไม่บังคับ)'}</span>
           </label>
           {errors.idCard && <p className="text-sm text-red-500 text-right ml-2">{errors.idCard[0]}</p>}
         </div>


### PR DESCRIPTION
## Summary
Removes the "(optional)" / "(ไม่บังคับ)" text and brackets displayed next to the **ID Card Number** field label in the reporter input form.

## Changes
- `components/ReporterInput.js`: removed the `<span>` rendering `(optional)` / `(ไม่บังคับ)` next to the ID card number label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxjhLtz6Znm9LkZ4nSK1jp)_